### PR TITLE
Use type member insted of type parameter for Entity and EntityId mapping

### DIFF
--- a/framework/ixias-aws-s3/src/main/scala/ixias/aws/s3/AmazonS3.scala
+++ b/framework/ixias-aws-s3/src/main/scala/ixias/aws/s3/AmazonS3.scala
@@ -19,7 +19,7 @@ import ixias.persistence.SlickRepository
 // S3 management repository
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~
 trait AmazonS3Repository[P <: JdbcProfile]
-    extends SlickRepository[File.Id, File, P] with SlickResource[P]
+    extends SlickRepository[File, P] with SlickResource[P]
 {
   import api._
 
@@ -37,7 +37,7 @@ trait AmazonS3Repository[P <: JdbcProfile]
   /**
    * Get file object.
    */
-  def get(id: Id): Future[Option[EntityEmbeddedId]] =
+  def get(id: File.Id): Future[Option[EntityEmbeddedId]] =
     RunDBAction(FileTable, "slave") { slick =>
       slick.unique(id).result.headOption
     }

--- a/framework/ixias-aws-s3/src/main/scala/ixias/aws/s3/model/File.scala
+++ b/framework/ixias-aws-s3/src/main/scala/ixias/aws/s3/model/File.scala
@@ -29,7 +29,9 @@ case class File(
   val presignedUrl: Option[java.net.URL] = None, // The presigned Url to accessing on Image
   val updatedAt:    LocalDateTime        = NOW,  // The Datetime when a data was updated.
   val createdAt:    LocalDateTime        = NOW   // The Datetime when a data was created.
-) extends EntityModel[File.Id] {
+) extends EntityModel {
+
+  type Id = File.Id
 
   lazy val httpsUrl       = s"${Protocol.HTTPS.toString()}://${httpsUrn}"
   lazy val httpsUrlOrigin = s"${Protocol.HTTPS.toString()}://${httpsUrnOrigin}"
@@ -53,18 +55,18 @@ object File {
   // --[ File ID ]--------------------------------------------------------------
   val  Id         = the[Identity[Id]]
   type Id         = Long @@ File
-  type WithNoId   = Entity.WithNoId   [Id, File]
-  type EmbeddedId = Entity.EmbeddedId [Id, File]
+  type WithNoId   = Entity.WithNoId   [File]
+  type EmbeddedId = Entity.EmbeddedId [File]
 
   object Config extends AmazonS3Config
 
   // --[ Create a new object ]--------------------------------------------------
   def apply(key: String, typedef: String, size: Option[ImageSize])
-    (implicit dns: DataSourceName): Try[Entity.WithNoId[File.Id, File]] =
+    (implicit dns: DataSourceName): Try[Entity.WithNoId[File]] =
     for {
       region <- Config.getAWSRegion
       bucket <- Config.getBucketName
-    } yield Entity.WithNoId[File.Id, File](
+    } yield Entity.WithNoId[File](
       new File(None, region.getName, bucket, key, typedef, size)
     )
 

--- a/framework/ixias-aws-s3/src/main/scala/ixias/aws/s3/model/FileResource.scala
+++ b/framework/ixias-aws-s3/src/main/scala/ixias/aws/s3/model/FileResource.scala
@@ -30,7 +30,7 @@ case class FileResource(
 // The companion object
 //~~~~~~~~~~~~~~~~~~~~~~
 object FileResource {
-  def apply(fid:  File.Id)                          = new FileResource(fid,     None)
-  def apply(file: Entity.EmbeddedId[File.Id, File]) = new FileResource(file.id, Some(file.v))
+  def apply(fid:  File.Id)                 = new FileResource(fid,     None)
+  def apply(file: Entity.EmbeddedId[File]) = new FileResource(file.id, Some(file.v))
 }
 

--- a/framework/ixias-core/src/main/scala/ixias/model/Entity.scala
+++ b/framework/ixias-core/src/main/scala/ixias/model/Entity.scala
@@ -18,7 +18,7 @@ object IdStatus {
 }
 
 /** The Entity */
-final case class Entity[K <: @@[_, _], +M <: EntityModel[K], S <: IdStatus](v: M) {
+final case class Entity[+M <: EntityModel, S <: IdStatus](v: M) {
 
   /** The entity data model */
   type Model    <: M
@@ -27,14 +27,14 @@ final case class Entity[K <: @@[_, _], +M <: EntityModel[K], S <: IdStatus](v: M
   type IdStatus =  S
 
   /** get id value whene id is exists */
-  def id(implicit ev: S =:= IdStatus.Exists): K = v.id.get
+  def id(implicit ev: S =:= IdStatus.Exists): M#Id = v.id.get
 
   /** check whether exists entity id value */
   def hasId(implicit ev: TypeTag[IdStatus]): Boolean =
     ev.tpe =:= typeOf[IdStatus.Exists]
 
   /** Builds a new `Entity` by applying a function to values. */
-  @inline def map[M2 <: EntityModel[K]](f: M => M2): Entity[K, M2, S] = new Entity(f(v))
+  @inline def map[M2 <: EntityModel](f: M => M2): Entity[M2, S] = new Entity(f(v))
 }
 
 // Companion object for Entity
@@ -43,10 +43,10 @@ object Entity {
 
   // Entity with no identity.
   //~~~~~~~~~~~~~~~~~~~~~~~~~~
-  type   WithNoId[K <: @@[_, _], M <: EntityModel[K]] = Entity[K, M, IdStatus.Empty]
+  type   WithNoId[M <: EntityModel] = Entity[M, IdStatus.Empty]
   object WithNoId {
     /** Create a entity object with no id. */
-    def apply[K <: @@[_, _], M <: EntityModel[K]](data: M): WithNoId[K, M] =
+    def apply[M <: EntityModel](data: M): WithNoId[M] =
       data.id match {
         case None    =>       new Entity(data)
         case Some(_) => throw new IllegalArgumentException("The entity's id is already setted.")
@@ -55,9 +55,9 @@ object Entity {
 
   // Entity has embedded Id.
   //~~~~~~~~~~~~~~~~~~~~~~~~~~
-  type   EmbeddedId[K <: @@[_, _], M <: EntityModel[K]] = Entity[K, M, IdStatus.Exists]
+  type   EmbeddedId[M <: EntityModel] = Entity[M, IdStatus.Exists]
   object EmbeddedId {
-    def apply[K <: @@[_, _], M <: EntityModel[K]](data: M): EmbeddedId[K, M] =
+    def apply[M <: EntityModel](data: M): EmbeddedId[M] =
       data.id match {
         case Some(_) =>       new Entity(data)
         case None    => throw new IllegalArgumentException("Coud not found id on entity's data.")

--- a/framework/ixias-core/src/main/scala/ixias/model/EntityModel.scala
+++ b/framework/ixias-core/src/main/scala/ixias/model/EntityModel.scala
@@ -13,10 +13,10 @@ import java.time.LocalDateTime
 /**
  * The definition for projecting domain model of DDD
  */
-trait EntityModel[K <: @@[_, _]] extends Serializable
+trait EntityModel extends Serializable
 {
   /** The type of entity id */
-  type Id = K
+  type Id <: @@[_, _]
 
   /** The entity's identity. */
   val id: Option[Id]

--- a/framework/ixias-core/src/main/scala/ixias/persistence/Repository.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/Repository.scala
@@ -8,7 +8,7 @@
 
 package ixias.persistence
 
-import ixias.model.{ @@, EntityModel }
+import ixias.model.EntityModel
 import ixias.persistence.dbio.{ Execution, EntityIOAction }
 import ixias.persistence.lifted.{ Aliases, ExtensionMethods }
 
@@ -48,5 +48,5 @@ private[persistence] trait Profile {
 /**
  * The basic repository with IOAction
  */
-trait Repository[K <: @@[_, _], M <: EntityModel[K]]
-    extends Profile with EntityIOAction[K, M]
+trait Repository[M <: EntityModel]
+    extends Profile with EntityIOAction[M]

--- a/framework/ixias-core/src/main/scala/ixias/persistence/SlickRepository.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/SlickRepository.scala
@@ -9,7 +9,7 @@
 package ixias.persistence
 
 import slick.jdbc.JdbcProfile
-import ixias.model.{ @@, EntityModel }
+import ixias.model.EntityModel
 import ixias.persistence.lifted._
 import ixias.persistence.backend.SlickBackend
 import ixias.persistence.action.SlickDBActionProvider
@@ -59,9 +59,9 @@ trait SlickProfile[P <: JdbcProfile]
 /**
  * The repository for persistence with using the Slick library.
  */
-trait SlickRepository[K <: @@[_, _], M <: EntityModel[K], P <: JdbcProfile]
-    extends Repository[K, M] with SlickProfile[P] {
+trait SlickRepository[M <: EntityModel, P <: JdbcProfile]
+    extends Repository[M] with SlickProfile[P] {
   trait API extends super.API
-      with SlickDBIOActionOps[K, M]
+      with SlickDBIOActionOps[M]
   override val api: API = new API {}
 }

--- a/framework/ixias-core/src/main/scala/ixias/persistence/dbio/EntityIOAction.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/dbio/EntityIOAction.scala
@@ -9,23 +9,23 @@
 package ixias.persistence.dbio
 
 import scala.concurrent.Future
-import ixias.model.{ @@, Entity, EntityModel, IdStatus }
+import ixias.model.{ Entity, EntityModel, IdStatus }
 import ixias.persistence.Repository
 
 /**
  * An Entity Action that can be executed on a persistence database.
  */
-trait EntityIOAction[K <: @@[_, _], M <: EntityModel[K]]
-    extends IOAction { self: Repository[K, M] =>
+trait EntityIOAction[M <: EntityModel]
+    extends IOAction { self: Repository[M] =>
 
   /** The type of entity id */
-  type Id = K
+  type Id = M#Id // FIXME: Why needs?
 
   /** The type of entity when it has not id. */
-  type EntityWithNoId   = Entity[K, M, IdStatus.Empty]
+  type EntityWithNoId   = Entity[M, IdStatus.Empty]
 
   /** The type of entity when it has embedded id */
-  type EntityEmbeddedId = Entity[K, M, IdStatus.Exists]
+  type EntityEmbeddedId = Entity[M, IdStatus.Exists]
 
   // --[ Methods ]--------------------------------------------------------------
   /**

--- a/framework/ixias-core/src/main/scala/ixias/persistence/lifted/ConverterOps.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/lifted/ConverterOps.scala
@@ -15,16 +15,16 @@ import scala.language.implicitConversions
 trait ConverterOps
 {
   // for EntityModel
-  implicit def toModelToEntity[K <: @@[_, _], M <: EntityModel[K]]
-    (m: M): Entity.EmbeddedId[K, M] = Entity.EmbeddedId[K, M](m)
+  implicit def toModelToEntity[M <: EntityModel]
+    (m: M): Entity.EmbeddedId[M] = Entity.EmbeddedId[M](m)
 
   // for Seq[EntityModel]
-  implicit def toModelToEntitySeq[K <: @@[_, _], M <: EntityModel[K]]
-    (m: Seq[M]): Seq[Entity.EmbeddedId[K, M]] = m.map(Entity.EmbeddedId[K, M](_))
+  implicit def toModelToEntitySeq[M <: EntityModel]
+    (m: Seq[M]): Seq[Entity.EmbeddedId[M]] = m.map(Entity.EmbeddedId[M](_))
 
   // for Option[EntityModel]
-  implicit def toModelToEntityOpt[K <: @@[_, _], M <: EntityModel[K]]
-    (m: Option[M]): Option[Entity.EmbeddedId[K, M]] = m.map(Entity.EmbeddedId[K, M](_))
+  implicit def toModelToEntityOpt[M <: EntityModel]
+    (m: Option[M]): Option[Entity.EmbeddedId[M]] = m.map(Entity.EmbeddedId[M](_))
 
   implicit def convert[A, B](o: A)(implicit conv: Converter[A, B]): B = conv.convert(o)
 }

--- a/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/AuthExtensionMethods.scala
+++ b/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/AuthExtensionMethods.scala
@@ -14,14 +14,14 @@ import ixias.play.api.mvc.BaseExtensionMethods
 trait AuthExtensionMethods extends BaseExtensionMethods { self: BaseControllerHelpers =>
 
   // For authentication
-  def Authenticated(auth: AuthProfile[_, _, _]): ActionBuilder[Request, AnyContent] =
+  def Authenticated(auth: AuthProfile[_, _]): ActionBuilder[Request, AnyContent] =
     AuthenticatedActionBuilder(auth, parse.default)
 
   // For authentication or not.
-  def AuthenticatedOrNot(auth: AuthProfile[_, _, _]): ActionBuilder[Request, AnyContent] =
+  def AuthenticatedOrNot(auth: AuthProfile[_, _]): ActionBuilder[Request, AnyContent] =
     AuthenticatedOrNotActionBuilder(auth, parse.default)
 
   // For authorization
-  def Authorized[T](auth: AuthProfile[_, _, T], authority: Option[T]): ActionBuilder[Request, AnyContent] =
+  def Authorized[T](auth: AuthProfile[_, T], authority: Option[T]): ActionBuilder[Request, AnyContent] =
     AuthorizedActionBuilder(auth, authority, parse.default)
 }

--- a/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/AuthProfile.scala
+++ b/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/AuthProfile.scala
@@ -14,19 +14,19 @@ import play.api.{ Environment, Mode }
 import play.api.mvc.{ RequestHeader, Result }
 import play.api.libs.typedmap.TypedKey
 
-import ixias.model.{ @@, Entity, EntityModel, IdStatus }
+import ixias.model.{ Entity, EntityModel, IdStatus }
 import ixias.play.api.auth.token.Token
 import ixias.play.api.auth.container.Container
 import ixias.play.api.mvc.Errors._
 
-trait AuthProfile[K <: @@[_, _], M <: EntityModel[K], A]
+trait AuthProfile[M <: EntityModel, A]
 {
   import Token._
 
   // --[ TypeDefs ]-------------------------------------------------------------
-  type Id         = K                              // The identity to detect authenticated resource.
+  type Id         = M#Id                              // The identity to detect authenticated resource.
   type Auth       = M                              // The authenticated resource.
-  type AuthEntity = Entity[K, M, IdStatus.Exists]  // The entity which is containing authenticated resource.
+  type AuthEntity = Entity[M, IdStatus.Exists]  // The entity which is containing authenticated resource.
   type Authority  = A                              // The type of authoriy
 
   /** Keys to request attributes. */

--- a/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/Authenticated.scala
+++ b/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/Authenticated.scala
@@ -16,7 +16,7 @@ import scala.concurrent.{ Future, ExecutionContext }
  */
 trait  AuthenticatedActionBuilder extends ActionBuilder[Request, AnyContent]
 object AuthenticatedActionBuilder {
-  def apply(auth: AuthProfile[_, _, _], parser: BodyParser[AnyContent])
+  def apply(auth: AuthProfile[_, _], parser: BodyParser[AnyContent])
     (implicit ec: ExecutionContext): AuthenticatedActionBuilder =
     new AuthenticatedActionBuilderImpl(auth, parser)
 }
@@ -24,7 +24,7 @@ object AuthenticatedActionBuilder {
 // Implementation for authentication
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class AuthenticatedActionBuilderImpl(
-  val auth:   AuthProfile[_, _, _],
+  val auth:   AuthProfile[_, _],
   val parser: BodyParser[AnyContent]
 )(implicit val executionContext: ExecutionContext) extends AuthenticatedActionBuilder {
 

--- a/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/AuthenticatedOrNot.scala
+++ b/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/AuthenticatedOrNot.scala
@@ -16,7 +16,7 @@ import scala.concurrent.{ Future, ExecutionContext }
  */
 trait  AuthenticatedOrNotActionBuilder extends ActionBuilder[Request, AnyContent]
 object AuthenticatedOrNotActionBuilder {
-  def apply(auth: AuthProfile[_, _, _], parser: BodyParser[AnyContent])
+  def apply(auth: AuthProfile[_, _], parser: BodyParser[AnyContent])
     (implicit ec: ExecutionContext): AuthenticatedOrNotActionBuilder =
     new AuthenticatedOrNotActionBuilderImpl(auth, parser)
 }
@@ -24,7 +24,7 @@ object AuthenticatedOrNotActionBuilder {
 // Implementation for authentication
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class AuthenticatedOrNotActionBuilderImpl(
-  val auth:   AuthProfile[_, _, _],
+  val auth:   AuthProfile[_, _],
   val parser: BodyParser[AnyContent]
 )(implicit val executionContext: ExecutionContext) extends AuthenticatedOrNotActionBuilder {
 

--- a/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/Authorized.scala
+++ b/framework/ixias-play-auth/src/main/scala/ixias/play/api/auth/mvc/Authorized.scala
@@ -16,7 +16,7 @@ import scala.concurrent.{ Future, ExecutionContext }
  */
 trait  AuthorizedActionBuilder extends ActionBuilder[Request, AnyContent]
 object AuthorizedActionBuilder {
-  def apply[T](auth: AuthProfile[_, _, T], authority: Option[T], parser: BodyParser[AnyContent])
+  def apply[T](auth: AuthProfile[_, T], authority: Option[T], parser: BodyParser[AnyContent])
     (implicit ec: ExecutionContext): AuthorizedActionBuilder =
     new AuthorizedActionBuilderImpl(auth, authority, parser)
 }
@@ -24,7 +24,7 @@ object AuthorizedActionBuilder {
 // Implementation for authorization
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class AuthorizedActionBuilderImpl[T](
-  val auth:      AuthProfile[_, _, T],
+  val auth:      AuthProfile[_, T],
   val authority: Option[T],
   val parser:    BodyParser[AnyContent]
 )(implicit val executionContext: ExecutionContext) extends AuthorizedActionBuilder {


### PR DESCRIPTION
Hi all, 

It is unnecessary to use type parameter for Entity and EntityId mapping.
Use of this type argument destroys the encapsulation, so the use of type members is recommended.

Diff indicates that you can write briefly on the user side.

Best regards.