### PR TITLE
AmazonQLDB: Fixed EnumBitFlags serialize/deserialize bugs

### DIFF
--- a/framework/ixias-aws-qldb/src/main/scala/ixias/aws/qldb/databind/EnumBitFlagsDeserializerModule.scala
+++ b/framework/ixias-aws-qldb/src/main/scala/ixias/aws/qldb/databind/EnumBitFlagsDeserializerModule.scala
@@ -35,18 +35,20 @@ case class EnumBitFlagsDeserializer(
 // Resolver to serve deserializer
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 object EnumBitFlagsDeserializerResolver extends Deserializers.Base {
-  private  val SYMBOL = classOf[Seq[EnumBitFlags]]
+  private  val SYMBOL  = classOf[Seq[_]]
+  private  val CONTENT = classOf[EnumBitFlags]
   override def findCollectionLikeDeserializer(
     collectionType:          CollectionLikeType,
     config:                  DeserializationConfig,
     beanDesc:                BeanDescription,
     elementTypeDeserializer: TypeDeserializer,
     elementDeserializer:     JsonDeserializer[_]
-  ): JsonDeserializer[_] = {
-    SYMBOL isAssignableFrom collectionType.getRawClass match {
-      case true  => EnumBitFlagsDeserializer(collectionType)
-      case false => null
-    }
+  ): JsonDeserializer[_] = (
+    (SYMBOL  isAssignableFrom collectionType.getRawClass) &&
+    (CONTENT isAssignableFrom collectionType.getContentType.getRawClass)
+  ) match {
+    case true  => EnumBitFlagsDeserializer(collectionType)
+    case false => null
   }
 }
 

--- a/framework/ixias-aws-qldb/src/main/scala/ixias/aws/qldb/databind/EnumBitFlagsSerializerModule.scala
+++ b/framework/ixias-aws-qldb/src/main/scala/ixias/aws/qldb/databind/EnumBitFlagsSerializerModule.scala
@@ -36,18 +36,20 @@ case class EnumBitFlagsSerializer(
 // Resolver to serve serializer
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 object EnumBitFlagsSerializerResolver extends Serializers.Base {
-  private  val SYMBOL = classOf[Seq[EnumBitFlags]]
+  private  val SYMBOL  = classOf[Seq[_]]
+  private  val CONTENT = classOf[EnumBitFlags]
   override def findCollectionLikeSerializer(
     config:                SerializationConfig,
     collectionType:        CollectionLikeType,
     beanDescription:       BeanDescription,
     elementTypeSerializer: TypeSerializer,
     elementSerializer:     JsonSerializer[Object]
-  ): JsonSerializer[_] = {
-    SYMBOL isAssignableFrom collectionType.getRawClass match {
-      case true  => EnumBitFlagsSerializer(collectionType)
-      case false => null
-    }
+  ): JsonSerializer[_] = (
+    (SYMBOL  isAssignableFrom collectionType.getRawClass) &&
+    (CONTENT isAssignableFrom collectionType.getContentType.getRawClass)
+  ) match {
+    case true  => EnumBitFlagsSerializer(collectionType)
+    case false => null
   }
 }
 


### PR DESCRIPTION
AmazonQLDB: Modified to check Seq element type when converting between AmazonIon and EnumBitset.