### PR TITLE
Enable `rewriteBatchedStatements=true` for JDBC to Improve Performance with BULK INSERT

### DIFF
--- a/framework/ixias-core/src/main/scala/ixias/persistence/backend/BasicDatabaseConfig.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/backend/BasicDatabaseConfig.scala
@@ -26,6 +26,7 @@ trait BasicDatabaseConfig {
   protected val CF_HOSTSPEC_DATABASE = "database"
   protected val CF_HOSTSPEC_SCHEMA   = "schema"
   protected val CF_HOSTSPEC_READONLY = "readonly"
+  protected val CF_REWRITE_BATCHED_STATEMENTS = "rewrite_batched_statements"
 
   /** The configuration */
   protected val config = Configuration()
@@ -83,4 +84,8 @@ trait BasicDatabaseConfig {
     }
     Try(opt)
   }
+
+  /** Get the flag for rewriteBatchedStatements. */
+  protected def getRewriteBatchedStatements(implicit dsn: DataSourceName): Boolean =
+    readValue(_.get[Option[Boolean]](CF_REWRITE_BATCHED_STATEMENTS)).getOrElse(false)
 }

--- a/framework/ixias-core/src/main/scala/ixias/persistence/backend/SlickBackend.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/backend/SlickBackend.scala
@@ -55,6 +55,9 @@ case class SlickBackend[P <: JdbcProfile](val driver: P)
         getHostSpecMaxPoolSize       map hconf.setMaximumPoolSize
         getHostSpecConnectionTimeout map hconf.setConnectionTimeout
         getHostSpecIdleTimeout       map hconf.setIdleTimeout
+        if (getRewriteBatchedStatements) {
+          hconf.addDataSourceProperty("rewriteBatchedStatements", true)
+        }
         HikariCPDataSource(new HikariDataSource(hconf), hconf)
       }
     }


### PR DESCRIPTION
## Summary

This pull request adds a configuration option to enable `rewriteBatchedStatements=true` during JDBC connections. This change aims to improve performance by using BULK INSERT syntax instead of executing multiple individual insert statements when inserting multiple records.

## Details

- **Feature:** Added a new configuration option to set `rewriteBatchedStatements=true` in JDBC connection strings.
- **Benefit:** This change allows MySQL to use BULK INSERT for batched insert operations, which can significantly improve performance by reducing the number of individual insert statements executed.
- **Usage:** You can enable this feature by adding `hostspec.rewrite_batched_statements = true` in the configuration file.

## References

- https://nextbeat.slack.com/archives/C06B4RV1R/p1582877716088400
